### PR TITLE
Sync in worker

### DIFF
--- a/src/matrix/Client.js
+++ b/src/matrix/Client.js
@@ -32,6 +32,7 @@ import {SSOLoginHelper} from "./login/SSOLoginHelper";
 import {getDehydratedDevice} from "./e2ee/Dehydration.js";
 import {Registration} from "./registration/Registration";
 import {FeatureSet} from "../features";
+import {SyncInWorker} from "./SyncInWorker";
 
 export const LoadStatus = createEnum(
     "NotLoading",
@@ -291,7 +292,7 @@ export class Client {
             await log.wrap("createIdentity", log => this._session.createIdentity(log));
         }
 
-        this._sync = new Sync({hsApi: this._requestScheduler.hsApi, storage: this._storage, session: this._session, logger: this._platform.logger});
+        this._sync = new SyncInWorker({hsApi: this._requestScheduler.hsApi, storage: this._storage, session: this._session, logger: this._platform.logger});
         // notify sync and session when back online
         this._reconnectSubscription = this._reconnector.connectionStatus.subscribe(state => {
             if (state === ConnectionStatus.Online) {

--- a/src/matrix/SyncInWorker.ts
+++ b/src/matrix/SyncInWorker.ts
@@ -3,6 +3,8 @@ import {HomeServerApi} from "./net/HomeServerApi";
 import {Session} from "./Session";
 import {Storage} from "./storage/idb/Storage";
 import {Logger} from "../logging/Logger";
+import {WorkerFacade} from "../platform/web/worker-sync/worker/WorkerFacade";
+import {StartSyncRequest} from "../platform/web/worker-sync/SyncWorker";
 
 interface SyncOptions {
     hsApi: HomeServerApi,
@@ -12,8 +14,11 @@ interface SyncOptions {
 }
 
 export class SyncInWorker extends Sync {
+    private _worker: WorkerFacade;
+
     constructor(options: SyncOptions) {
         super(options);
+        this._worker = new WorkerFacade;
     }
 
     get status(): SyncStatus {
@@ -25,7 +30,10 @@ export class SyncInWorker extends Sync {
     }
 
     start(): void {
-        super.start();
+        const message = new StartSyncRequest({
+            sessionInfo: super.options.sessionInfo,
+        });
+        const result = this._worker.sendAndWaitForReply(message);
     }
 
     stop(): void {

--- a/src/matrix/SyncInWorker.ts
+++ b/src/matrix/SyncInWorker.ts
@@ -1,4 +1,4 @@
-import {Sync} from "./Sync";
+import {Sync, SyncStatus} from "./Sync";
 import {HomeServerApi} from "./net/HomeServerApi";
 import {Session} from "./Session";
 import {Storage} from "./storage/idb/Storage";
@@ -14,5 +14,21 @@ interface SyncOptions {
 export class SyncInWorker extends Sync {
     constructor(options: SyncOptions) {
         super(options);
+    }
+
+    get status(): SyncStatus {
+        return super.status;
+    }
+
+    get error(): Error {
+        return super.error;
+    }
+
+    start(): void {
+        super.start();
+    }
+
+    stop(): void {
+        super.stop();
     }
 }

--- a/src/matrix/SyncInWorker.ts
+++ b/src/matrix/SyncInWorker.ts
@@ -1,0 +1,18 @@
+import {Sync} from "./Sync";
+import {HomeServerApi} from "./net/HomeServerApi";
+import {Session} from "./Session";
+import {Storage} from "./storage/idb/Storage";
+import {Logger} from "../logging/Logger";
+
+interface SyncOptions {
+    hsApi: HomeServerApi,
+    session: Session,
+    storage: Storage,
+    logger: Logger
+}
+
+export class SyncInWorker extends Sync {
+    constructor(options: SyncOptions) {
+        super(options);
+    }
+}

--- a/src/matrix/sessioninfo/localstorage/SessionInfoStorage.ts
+++ b/src/matrix/sessioninfo/localstorage/SessionInfoStorage.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-interface ISessionInfo {
+export interface ISessionInfo {
     id: string;
     deviceId: string;
     userId: string;

--- a/src/matrix/storage/idb/StorageFactory.ts
+++ b/src/matrix/storage/idb/StorageFactory.ts
@@ -52,12 +52,12 @@ async function requestPersistedStorage(): Promise<boolean> {
 }
 
 export class StorageFactory {
-    private _serviceWorkerHandler: ServiceWorkerHandler;
+    private _serviceWorkerHandler?: ServiceWorkerHandler;
     private _idbFactory: IDBFactory;
     private _IDBKeyRange: typeof IDBKeyRange;
     private _localStorage: IDOMStorage;
 
-    constructor(serviceWorkerHandler: ServiceWorkerHandler, idbFactory: IDBFactory = window.indexedDB, _IDBKeyRange = window.IDBKeyRange, localStorage: IDOMStorage = window.localStorage) {
+    constructor(serviceWorkerHandler?: ServiceWorkerHandler, idbFactory: IDBFactory = window.indexedDB, _IDBKeyRange = window.IDBKeyRange, localStorage: IDOMStorage = window.localStorage) {
         this._serviceWorkerHandler = serviceWorkerHandler;
         this._idbFactory = idbFactory;
         this._IDBKeyRange = _IDBKeyRange;

--- a/src/matrix/storage/idb/StorageFactory.ts
+++ b/src/matrix/storage/idb/StorageFactory.ts
@@ -55,13 +55,16 @@ export class StorageFactory {
     private _serviceWorkerHandler?: ServiceWorkerHandler;
     private _idbFactory: IDBFactory;
     private _IDBKeyRange: typeof IDBKeyRange;
-    private _localStorage: IDOMStorage;
+    private _localStorage?: IDOMStorage;
 
-    constructor(serviceWorkerHandler?: ServiceWorkerHandler, idbFactory: IDBFactory = indexedDB, _IDBKeyRange = IDBKeyRange, localStorage: IDOMStorage = window?.localStorage ?? undefined) {
+    constructor(serviceWorkerHandler?: ServiceWorkerHandler, idbFactory: IDBFactory = indexedDB, _IDBKeyRange = IDBKeyRange, _localStorage: IDOMStorage | undefined = undefined) {
         this._serviceWorkerHandler = serviceWorkerHandler;
         this._idbFactory = idbFactory;
         this._IDBKeyRange = _IDBKeyRange;
-        this._localStorage = localStorage;
+        if (typeof window !== 'undefined' && _localStorage === undefined) {
+            _localStorage = localStorage;
+        }
+        this._localStorage = _localStorage;
     }
 
     async create(sessionId: string, log: ILogItem): Promise<Storage> {

--- a/src/matrix/storage/idb/StorageFactory.ts
+++ b/src/matrix/storage/idb/StorageFactory.ts
@@ -57,7 +57,7 @@ export class StorageFactory {
     private _IDBKeyRange: typeof IDBKeyRange;
     private _localStorage: IDOMStorage;
 
-    constructor(serviceWorkerHandler?: ServiceWorkerHandler, idbFactory: IDBFactory = window.indexedDB, _IDBKeyRange = window.IDBKeyRange, localStorage: IDOMStorage = window.localStorage) {
+    constructor(serviceWorkerHandler?: ServiceWorkerHandler, idbFactory: IDBFactory = indexedDB, _IDBKeyRange = IDBKeyRange, localStorage: IDOMStorage = window?.localStorage ?? undefined) {
         this._serviceWorkerHandler = serviceWorkerHandler;
         this._idbFactory = idbFactory;
         this._IDBKeyRange = _IDBKeyRange;

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -153,6 +153,7 @@ export class Platform {
         this._syncWorkerPool = null;
         if (assetPaths.syncWorker && window.Worker) {
             this._syncWorkerPool = new SyncWorkerPool(this._assetPaths.syncWorker);
+            this._syncWorkerPool.add("my-session-id");
         }
         this.notificationService = undefined;
         // Only try to use crypto when olm is provided

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -153,7 +153,7 @@ export class Platform {
         this._syncWorkerPool = null;
         if (assetPaths.syncWorker && window.Worker) {
             this._syncWorkerPool = new SyncWorkerPool(this._assetPaths.syncWorker);
-            this._syncWorkerPool.add("my-session-id");
+            this._syncWorkerPool.add("1646528482480255");
         }
         this.notificationService = undefined;
         // Only try to use crypto when olm is provided

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -151,10 +151,6 @@ export class Platform {
             this._serviceWorkerHandler.registerAndStart(assetPaths.serviceWorker);
         }
         this._syncWorkerPool = null;
-        if (assetPaths.syncWorker && window.Worker) {
-            this._syncWorkerPool = new SyncWorkerPool(this._assetPaths.syncWorker);
-            this._syncWorkerPool.add("1646528482480255");
-        }
         this.notificationService = undefined;
         // Only try to use crypto when olm is provided
         if(this._assetPaths.olm) {
@@ -179,6 +175,11 @@ export class Platform {
         this.mediaDevices = new MediaDevicesWrapper(navigator.mediaDevices);
         this.webRTC = new DOMWebRTC();
         this._themeLoader = import.meta.env.DEV? null: new ThemeLoader(this);
+
+        if (assetPaths.syncWorker && window.Worker) {
+            this._syncWorkerPool = new SyncWorkerPool(this._assetPaths.syncWorker, this.sessionInfoStorage);
+            this._syncWorkerPool.add("1646528482480255");
+        }
     }
 
     async init() {

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -178,7 +178,7 @@ export class Platform {
 
         if (assetPaths.syncWorker && window.Worker) {
             this._syncWorkerPool = new SyncWorkerPool(this._assetPaths.syncWorker, this.sessionInfoStorage);
-            this._syncWorkerPool.add("1646528482480255");
+            this._syncWorkerPool.add("750343279252151");
         }
     }
 

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -43,6 +43,7 @@ import {MediaDevicesWrapper} from "./dom/MediaDevices";
 import {DOMWebRTC} from "./dom/WebRTC";
 import {ThemeLoader} from "./theming/ThemeLoader";
 import {TimeFormatter} from "./dom/TimeFormatter";
+import {SyncWorkerPool} from "./worker-sync/SyncWorkerPool";
 
 function addScript(src) {
     return new Promise(function (resolve, reject) {
@@ -148,6 +149,10 @@ export class Platform {
         if (assetPaths.serviceWorker && "serviceWorker" in navigator) {
             this._serviceWorkerHandler = new ServiceWorkerHandler();
             this._serviceWorkerHandler.registerAndStart(assetPaths.serviceWorker);
+        }
+        this._syncWorkerPool = null;
+        if (assetPaths.syncWorker && window.Worker) {
+            this._syncWorkerPool = new SyncWorkerPool(this._assetPaths.syncWorker);
         }
         this.notificationService = undefined;
         // Only try to use crypto when olm is provided

--- a/src/platform/web/sdk/paths/vite.js
+++ b/src/platform/web/sdk/paths/vite.js
@@ -2,6 +2,7 @@
 import _downloadSandboxPath from "../../assets/download-sandbox.html?url";
 // @ts-ignore
 import _workerPath from "../../worker/main.js?url";
+import _syncWorkerPath from "../../worker-sync/sync-worker.js?url";
 // @ts-ignore
 import olmWasmPath from "@matrix-org/olm/olm.wasm?url";
 // @ts-ignore
@@ -12,6 +13,7 @@ import olmLegacyJsPath from "@matrix-org/olm/olm_legacy.js?url";
 export default {
     downloadSandbox: _downloadSandboxPath,
     worker: _workerPath,
+    syncWorker: _syncWorkerPath,
     olm: {
         wasm: olmWasmPath,
         legacyBundle: olmLegacyJsPath,

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -1,0 +1,15 @@
+class SyncWorker {
+    constructor() {
+        self.addEventListener("message", this.onMessage);
+    }
+
+    private onMessage(event: MessageEvent<string>) {
+        console.log(event)
+        const data = event.data;
+        console.log(data);
+        postMessage(data);
+    }
+}
+
+// @ts-ignore
+self.syncWorker = new SyncWorker();

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -12,6 +12,7 @@ import {Storage} from "../../../matrix/storage/idb/Storage";
 import {StorageFactory} from "../../../matrix/storage/idb/StorageFactory";
 import {NullLogger} from "../../../logging/NullLogger";
 import {MediaRepository} from "../../../matrix/net/MediaRepository";
+import {FeatureSet} from "../../../features";
 
 type Payload = object;
 
@@ -69,6 +70,8 @@ class SyncWorker {
             homeserver: sessionInfo.homeServer,
             platform: this._platform,
         });
+
+        const features = new FeatureSet;
 
         const session = new Session({
             storage: this._storage,

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -13,6 +13,7 @@ import {MediaRepository} from "../../../matrix/net/MediaRepository";
 import {FeatureSet} from "../../../features";
 import {Logger} from "../../../logging/Logger";
 import {ConsoleReporter} from "../../../logging/ConsoleReporter";
+import assetPaths from "../sdk/paths/vite";
 
 type Payload = object;
 
@@ -39,7 +40,7 @@ class SyncWorker {
         const sessionInfo = payload.sessionInfo;
         console.log(`Starting sync worker for session with id ${sessionInfo.id}`);
 
-        this._platform = new WorkerPlatform();
+        this._platform = new WorkerPlatform({assetPaths});
 
         this._reconnector = new Reconnector({
             onlineStatus: new OnlineStatus(),

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -7,6 +7,7 @@ import {ExponentialRetryDelay} from "../../../matrix/net/ExponentialRetryDelay";
 import {OnlineStatus} from "../dom/OnlineStatus";
 import {Sync} from "../../../matrix/Sync";
 import {Session} from "../../../matrix/Session";
+import {WorkerPlatform} from "./WorkerPlatform";
 
 type Payload = object;
 
@@ -26,6 +27,7 @@ export interface StartSyncPayload extends Payload {
 class SyncWorker {
     private _clock: Clock;
     private _reconnector: Reconnector;
+    private _platform: WorkerPlatform;
     private _sync: Sync;
 
     async start(payload: StartSyncPayload): Promise<Payload> {
@@ -47,13 +49,15 @@ class SyncWorker {
             reconnector: this._reconnector,
         });
 
+        this._platform = new WorkerPlatform();
+
         const session = new Session({
             storage,
             hsApi,
             sessionInfo,
             olm,
             olmWorker,
-            platform,
+            platform: this._platform,
             mediaRepository,
             features,
         });

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -9,9 +9,10 @@ import {Session} from "../../../matrix/Session";
 import {WorkerPlatform} from "./WorkerPlatform";
 import {Storage} from "../../../matrix/storage/idb/Storage";
 import {StorageFactory} from "../../../matrix/storage/idb/StorageFactory";
-import {NullLogger} from "../../../logging/NullLogger";
 import {MediaRepository} from "../../../matrix/net/MediaRepository";
 import {FeatureSet} from "../../../features";
+import {Logger} from "../../../logging/Logger";
+import {ConsoleReporter} from "../../../logging/ConsoleReporter";
 
 type Payload = object;
 
@@ -53,10 +54,10 @@ class SyncWorker {
             reconnector: this._reconnector,
         });
 
-        this._platform = new WorkerPlatform();
+        const logger = new Logger({platform: this._platform});
+        logger.addReporter(new ConsoleReporter());
 
         const storageFactory = new StorageFactory();
-        const logger = new NullLogger;
         await logger.run("", async log => {
             this._storage = await storageFactory.create(sessionInfo.id, log)
         });

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -1,15 +1,40 @@
-class SyncWorker {
-    constructor() {
-        self.addEventListener("message", this.onMessage);
-    }
+import {SessionId} from "./SyncWorkerPool";
 
-    private onMessage(event: MessageEvent<string>) {
-        console.log(event)
-        const data = event.data;
-        console.log(data);
-        postMessage(data);
+type Payload = object;
+
+export enum SyncWorkerMessageType {
+    StartSync,
+}
+
+interface Message {
+    type: SyncWorkerMessageType,
+    payload: Payload
+}
+
+export interface StartSyncPayload extends Payload {
+    sessionId: SessionId,
+}
+
+class SyncWorker {
+    start(payload: StartSyncPayload): Payload {
+        console.log(`Starting sync for session with id ${payload.sessionId}`);
+        return payload;
     }
 }
 
+const worker = new SyncWorker();
 // @ts-ignore
-self.syncWorker = new SyncWorker();
+self.syncWorker = worker;
+
+self.addEventListener("message", event => {
+    const data: Message = event.data;
+
+    let reply: Payload;
+    switch (data.type) {
+        case SyncWorkerMessageType.StartSync:
+            reply = worker.start(data.payload as StartSyncPayload);
+            break;
+    }
+
+    postMessage(reply);
+});

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -61,6 +61,9 @@ class SyncWorker {
             this._storage = await storageFactory.create(sessionInfo.id, log)
         });
 
+        const olm = this._platform.loadOlm();
+        const olmWorker = await this._platform.loadOlmWorker();
+
         const session = new Session({
             storage: this._storage,
             hsApi,

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -5,6 +5,8 @@ import {Clock} from "../dom/Clock";
 import {Reconnector} from "../../../matrix/net/Reconnector";
 import {ExponentialRetryDelay} from "../../../matrix/net/ExponentialRetryDelay";
 import {OnlineStatus} from "../dom/OnlineStatus";
+import {Sync} from "../../../matrix/Sync";
+import {Session} from "../../../matrix/Session";
 
 type Payload = object;
 
@@ -24,6 +26,7 @@ export interface StartSyncPayload extends Payload {
 class SyncWorker {
     private _clock: Clock;
     private _reconnector: Reconnector;
+    private _sync: Sync;
 
     async start(payload: StartSyncPayload): Promise<Payload> {
         const sessionInfo = payload.sessionInfo;
@@ -44,6 +47,23 @@ class SyncWorker {
             reconnector: this._reconnector,
         });
 
+        const session = new Session({
+            storage,
+            hsApi,
+            sessionInfo,
+            olm,
+            olmWorker,
+            platform,
+            mediaRepository,
+            features,
+        });
+
+        this._sync = new Sync({
+            hsApi,
+            session,
+            storage,
+            logger,
+        });
 
         return payload;
     }

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -11,6 +11,7 @@ import {WorkerPlatform} from "./WorkerPlatform";
 import {Storage} from "../../../matrix/storage/idb/Storage";
 import {StorageFactory} from "../../../matrix/storage/idb/StorageFactory";
 import {NullLogger} from "../../../logging/NullLogger";
+import {MediaRepository} from "../../../matrix/net/MediaRepository";
 
 type Payload = object;
 
@@ -63,6 +64,11 @@ class SyncWorker {
 
         const olm = this._platform.loadOlm();
         const olmWorker = await this._platform.loadOlmWorker();
+
+        const mediaRepository = new MediaRepository({
+            homeserver: sessionInfo.homeServer,
+            platform: this._platform,
+        });
 
         const session = new Session({
             storage: this._storage,

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -1,7 +1,6 @@
 import {ISessionInfo} from "../../../matrix/sessioninfo/localstorage/SessionInfoStorage";
 import {HomeServerApi} from "../../../matrix/net/HomeServerApi";
 import {createFetchRequest} from "../dom/request/fetch";
-import {Clock} from "../dom/Clock";
 import {Reconnector} from "../../../matrix/net/Reconnector";
 import {ExponentialRetryDelay} from "../../../matrix/net/ExponentialRetryDelay";
 import {OnlineStatus} from "../dom/OnlineStatus";
@@ -30,7 +29,6 @@ export interface StartSyncPayload extends Payload {
 }
 
 class SyncWorker {
-    private _clock: Clock;
     private _reconnector: Reconnector;
     private _platform: WorkerPlatform;
     private _storage: Storage;
@@ -40,18 +38,18 @@ class SyncWorker {
         const sessionInfo = payload.sessionInfo;
         console.log(`Starting sync worker for session with id ${sessionInfo.id}`);
 
-        this._clock = new Clock;
+        this._platform = new WorkerPlatform();
 
         this._reconnector = new Reconnector({
             onlineStatus: new OnlineStatus(),
-            retryDelay: new ExponentialRetryDelay(this._clock.createTimeout),
-            createMeasure: this._clock.createMeasure
+            retryDelay: new ExponentialRetryDelay(this._platform.clock.createTimeout),
+            createMeasure: this._platform.clock.createMeasure
         });
 
         const hsApi = new HomeServerApi({
             homeserver: sessionInfo.homeserver,
             accessToken: sessionInfo.accessToken,
-            request: createFetchRequest(this._clock.createTimeout),
+            request: createFetchRequest(this._platform.clock.createTimeout),
             reconnector: this._reconnector,
         });
 

--- a/src/platform/web/worker-sync/SyncWorker.ts
+++ b/src/platform/web/worker-sync/SyncWorker.ts
@@ -14,18 +14,28 @@ import {FeatureSet} from "../../../features";
 import {Logger} from "../../../logging/Logger";
 import {ConsoleReporter} from "../../../logging/ConsoleReporter";
 import assetPaths from "../sdk/paths/vite";
-import {MessageBody, ResultBody, Worker} from "./worker/Worker";
+import {Request, RequestData, Response, ResponseData, Worker} from "./worker/Worker";
 
-export enum SyncMessageType {
+enum SyncRequestType {
     StartSync = "StartSync",
 }
 
-export interface StartSyncMessage extends MessageBody {
+interface StartSyncRequestData extends RequestData {
     sessionInfo: ISessionInfo,
 }
 
-export interface StartSyncResult extends ResultBody {
+interface StartSyncResponseData extends ResponseData {
     success: boolean,
+}
+
+export class StartSyncRequest implements Request {
+    readonly type: SyncRequestType;
+    readonly data: StartSyncRequestData;
+
+    constructor(data: StartSyncRequestData) {
+        this.type = SyncRequestType.StartSync;
+        this.data = data;
+    }
 }
 
 export class SyncWorker extends Worker {
@@ -36,11 +46,11 @@ export class SyncWorker extends Worker {
 
     constructor() {
         super();
-        super.addHandler(SyncMessageType.StartSync, this.startSync.bind(this));
+        super.addHandler(SyncRequestType.StartSync, this.startSync.bind(this));
     }
 
-    async startSync(message: StartSyncMessage): Promise<StartSyncResult> {
-        const sessionInfo = message.sessionInfo;
+    async startSync(request: StartSyncRequest): Promise<StartSyncResponseData> {
+        const sessionInfo = request.data.sessionInfo;
         console.log(`Starting sync worker for session with id ${sessionInfo.id}`);
 
         this._platform = new WorkerPlatform({assetPaths});

--- a/src/platform/web/worker-sync/SyncWorkerPool.ts
+++ b/src/platform/web/worker-sync/SyncWorkerPool.ts
@@ -1,5 +1,5 @@
-import {SyncMessageType} from "./SyncWorker";
 import {SessionInfoStorage} from "../../../matrix/sessioninfo/localstorage/SessionInfoStorage";
+import {StartSyncRequest} from "./SyncWorker";
 
 export type SessionId = string;
 
@@ -30,11 +30,15 @@ export class SyncWorkerPool {
         }
 
         const sessionInfo = await this._sessionInfoStorage.get(sessionId);
+        if (!sessionInfo) {
+            // TODO
+            return;
+        }
+
+        const message = new StartSyncRequest({sessionInfo})
         worker.postMessage({
-            type: SyncMessageType.StartSync,
-            body: {
-                sessionInfo: sessionInfo
-            },
+            type: message.type,
+            data: message.data,
         });
     }
 

--- a/src/platform/web/worker-sync/SyncWorkerPool.ts
+++ b/src/platform/web/worker-sync/SyncWorkerPool.ts
@@ -1,4 +1,4 @@
-import {SyncWorkerMessageType} from "./SyncWorker";
+import {SyncMessageType} from "./SyncWorker";
 import {SessionInfoStorage} from "../../../matrix/sessioninfo/localstorage/SessionInfoStorage";
 
 export type SessionId = string;
@@ -31,8 +31,8 @@ export class SyncWorkerPool {
 
         const sessionInfo = await this._sessionInfoStorage.get(sessionId);
         worker.postMessage({
-            type: SyncWorkerMessageType.StartSync,
-            payload: {
+            type: SyncMessageType.StartSync,
+            body: {
                 sessionInfo: sessionInfo
             },
         });

--- a/src/platform/web/worker-sync/SyncWorkerPool.ts
+++ b/src/platform/web/worker-sync/SyncWorkerPool.ts
@@ -1,0 +1,20 @@
+export class SyncWorkerPool {
+    private readonly _worker: Worker;
+
+    constructor(path: string) {
+        this._worker = new Worker(path, {type: "module"});
+        this._worker.postMessage({
+            hello: {
+                foo: "foo",
+                bar: "bar",
+            },
+            world: {
+                baz: "baz"
+            },
+        });
+        this._worker.onmessage = (e) => {
+            const reply = e.data;
+            console.log(reply);
+        }
+    }
+}

--- a/src/platform/web/worker-sync/SyncWorkerPool.ts
+++ b/src/platform/web/worker-sync/SyncWorkerPool.ts
@@ -1,4 +1,6 @@
-type SessionId = string;
+import {SyncWorkerMessageType} from "./SyncWorker";
+
+export type SessionId = string;
 
 export class SyncWorkerPool {
     private readonly _workers: Map<SessionId, Worker> = new Map;
@@ -25,13 +27,10 @@ export class SyncWorkerPool {
         }
 
         worker.postMessage({
-            hello: {
-                foo: "foo",
-                bar: "bar",
-            },
-            world: {
-                baz: "baz"
-            },
+            type: SyncWorkerMessageType.StartSync,
+            payload: {
+                sessionId: sessionId,
+            }
         });
     }
 

--- a/src/platform/web/worker-sync/WorkerPlatform.ts
+++ b/src/platform/web/worker-sync/WorkerPlatform.ts
@@ -1,4 +1,12 @@
 export class WorkerPlatform {
     constructor() {
     }
+
+    loadOlm() {
+        return null;
+    }
+
+    async loadOlmWorker() {
+        return null;
+    }
 }

--- a/src/platform/web/worker-sync/WorkerPlatform.ts
+++ b/src/platform/web/worker-sync/WorkerPlatform.ts
@@ -2,8 +2,10 @@ import {Clock} from "../dom/Clock";
 
 export class WorkerPlatform {
     private readonly _clock: Clock;
+    private _assetPaths: any;
 
-    constructor() {
+    constructor({assetPaths}) {
+        this._assetPaths = assetPaths;
         this._clock = new Clock;
     }
 

--- a/src/platform/web/worker-sync/WorkerPlatform.ts
+++ b/src/platform/web/worker-sync/WorkerPlatform.ts
@@ -1,5 +1,10 @@
+import {Clock} from "../dom/Clock";
+
 export class WorkerPlatform {
+    private readonly _clock: Clock;
+
     constructor() {
+        this._clock = new Clock;
     }
 
     loadOlm() {
@@ -8,5 +13,9 @@ export class WorkerPlatform {
 
     async loadOlmWorker() {
         return null;
+    }
+
+    get clock(): Clock {
+        return this._clock;
     }
 }

--- a/src/platform/web/worker-sync/WorkerPlatform.ts
+++ b/src/platform/web/worker-sync/WorkerPlatform.ts
@@ -1,0 +1,4 @@
+export class WorkerPlatform {
+    constructor() {
+    }
+}

--- a/src/platform/web/worker-sync/sync-worker.js
+++ b/src/platform/web/worker-sync/sync-worker.js
@@ -1,0 +1,1 @@
+import "./SyncWorker";

--- a/src/platform/web/worker-sync/sync-worker.js
+++ b/src/platform/web/worker-sync/sync-worker.js
@@ -1,1 +1,5 @@
-import "./SyncWorker";
+import {SyncWorker} from "./SyncWorker";
+
+const worker = new SyncWorker();
+worker.start();
+self.syncWorker = worker;

--- a/src/platform/web/worker-sync/sync-worker.js
+++ b/src/platform/web/worker-sync/sync-worker.js
@@ -1,5 +1,5 @@
 import {SyncWorker} from "./SyncWorker";
 
 const worker = new SyncWorker();
-worker.init().then(() => worker.start());
+void worker.start();
 self.syncWorker = worker;

--- a/src/platform/web/worker-sync/sync-worker.js
+++ b/src/platform/web/worker-sync/sync-worker.js
@@ -1,5 +1,5 @@
 import {SyncWorker} from "./SyncWorker";
 
 const worker = new SyncWorker();
-worker.start();
+worker.init().then(() => worker.start());
 self.syncWorker = worker;

--- a/src/platform/web/worker-sync/worker/Worker.ts
+++ b/src/platform/web/worker-sync/worker/Worker.ts
@@ -34,6 +34,11 @@ export abstract class Worker {
         this._handlers.set(type, handler);
     }
 
+    async init(): Promise<void> {
+        // Extending classes can override this method as needed to perform async initialization.
+        return;
+    }
+
     start() {
         if (self.onmessage) {
             throw `${this.class} is already started`;

--- a/src/platform/web/worker-sync/worker/Worker.ts
+++ b/src/platform/web/worker-sync/worker/Worker.ts
@@ -34,17 +34,19 @@ export abstract class Worker {
         this._handlers.set(type, handler);
     }
 
-    async init(): Promise<void> {
+    protected async init(): Promise<void> {
         // Extending classes can override this method as needed to perform async initialization.
         return;
     }
 
-    start() {
+    async start() {
         if (self.onmessage) {
             throw `${this.class} is already started`;
         }
 
+        await this.init();
         self.onmessage = (event: MessageEvent) => void this.onRequest(event);
+        postMessage({ started: true });
     }
 
     private async onRequest(event: MessageEvent) {
@@ -55,7 +57,6 @@ export abstract class Worker {
 
     private async handle(request: Request): Promise<Response> {
         const handler = this._handlers.get(request.type);
-
         if (!handler) {
             throw `No handler is registered in ${this.class} for requests of type ${request.type}`;
         }

--- a/src/platform/web/worker-sync/worker/Worker.ts
+++ b/src/platform/web/worker-sync/worker/Worker.ts
@@ -1,0 +1,72 @@
+/// <reference lib="webworker" />
+declare let self: DedicatedWorkerGlobalScope
+
+export type MessageBody = object;
+export type ResultBody = object;
+
+type MessageType = string;
+
+interface Message {
+    type: MessageType,
+    body: MessageBody
+}
+interface Result {
+    type: MessageType,
+    body: ResultBody,
+}
+
+type MessageHandler = (body: MessageBody) => Promise<ResultBody>;
+type HandlerMap = Map<MessageType, MessageHandler>;
+
+export abstract class Worker {
+    private readonly _handlers: HandlerMap = new Map;
+
+    protected constructor() {
+        const isWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
+        if (!isWorker) {
+            throw `${this.class} can only be used in Workers, it cannot be used in the main thread.`;
+        }
+    }
+
+    protected addHandler(type: MessageType, handler: MessageHandler) {
+        this._handlers.set(type, handler);
+    }
+
+    start() {
+        if (self.onmessage) {
+            throw `${this.class} is already started`;
+        }
+
+        self.onmessage = (event: MessageEvent) => void this.onMessage(event);
+    }
+
+    private async onMessage(event: MessageEvent) {
+        const message = event.data as Message;
+        try {
+            const result = await this.handle(message);
+            postMessage(result);
+        } catch (error) {
+            console.error(error);
+            return;
+        }
+    }
+
+    private async handle(message: Message): Promise<Result> {
+        const handler = this._handlers.get(message.type);
+
+        if (!handler) {
+            throw `No handler is registered in ${this.class} for messages of type ${message.type}`;
+        }
+
+        const result = await handler(message.body);
+        return {
+            type: message.type,
+            body: result,
+        };
+    }
+
+    private get class(): string {
+        // Returns the name of the actual class that extends Worker.
+        return this.constructor.name;
+    }
+}

--- a/src/platform/web/worker-sync/worker/WorkerFacade.ts
+++ b/src/platform/web/worker-sync/worker/WorkerFacade.ts
@@ -1,0 +1,11 @@
+import {Request, ResponseData} from "./Worker";
+
+export class WorkerFacade {
+    async sendAndWaitForReply(request: Request): Promise<ResponseData> {
+        // TODO
+        return {
+            type: request.type,
+            data: { success: true }
+        };
+    }
+}

--- a/src/platform/web/worker-sync/worker/WorkerPool.ts
+++ b/src/platform/web/worker-sync/worker/WorkerPool.ts
@@ -1,0 +1,28 @@
+type WorkerId = string;
+
+export abstract class WorkerPool {
+    private readonly _workerAssetPath: string;
+    private readonly _workers: Map<WorkerId, Worker> = new Map;
+
+    protected constructor(workerAssetPath: string) {
+        this._workerAssetPath = workerAssetPath;
+    }
+
+    async start(id: WorkerId) {
+        const worker = new Worker(this._workerAssetPath, {type: "module"});
+        worker.onmessageerror
+        worker.onerror
+        worker.onmessage
+        this._workers.set(id, worker);
+    }
+
+    async stop(id: WorkerId) {
+        const worker = this._workers.get(id);
+        if (!worker) {
+            throw `Worker with id ${id} does not exist`;
+        }
+
+        worker.terminate();
+        this._workers.delete(id);
+    }
+}


### PR DESCRIPTION
WIP

This is an exploration, this PR is not intended to be merged. This might result in a PR to upstream hydrogen, or we could end up dropping it entirely.

Related to https://github.com/Automattic/chatrix/issues/159

## TODO

- [ ] Make olm functional in sync worker
- [ ] Make sync in a worker functional, without caring about "forwarding" state to the UI thread
- [ ] "Forward" state from sync worker to UI thread

## Refactors that could be necessary and/or nice-to-have
- Rename `WorkerPool` and related files/classes to `OlmWorkerPool`
- Base `Worker` abstraction
- Improve worker-related directory structure
- Have `vite` handle worker paths