### PR TITLE
Run sync in worker

### DIFF
--- a/src/matrix/Client.js
+++ b/src/matrix/Client.js
@@ -88,11 +88,7 @@ export class Client {
         await this._platform.logger.run("load session", async log => {
             log.set("id", sessionId);
             try {
-                const sessionInfo = await this._platform.sessionInfoStorage.get(sessionId);
-                if (!sessionInfo) {
-                    throw new Error("Invalid session id: " + sessionId);
-                }
-                await this._loadSessionInfo(sessionInfo, null, log);
+                await this._loadSessionInfo(sessionId, null, log);
                 log.set("status", this._status.get());
             } catch (err) {
                 log.catch(err);
@@ -225,7 +221,7 @@ export class Client {
         // LoadStatus.Error in case of an error,
         // so separate try/catch
         try {
-            await this._loadSessionInfo(sessionInfo, dehydratedDevice, log);
+            await this._loadSessionInfo(id, dehydratedDevice, log);
             log.set("status", this._status.get());
         } catch (err) {
             log.catch(err);
@@ -236,8 +232,14 @@ export class Client {
         }
     }
 
-    async _loadSessionInfo(sessionInfo, dehydratedDevice, log) {
+    async _loadSessionInfo(sessionId, dehydratedDevice, log) {
         log.set("appVersion", this._platform.version);
+
+        const sessionInfo = await this._platform.sessionInfoStorage.get(sessionId);
+        if (!sessionInfo) {
+            throw new Error("Invalid session id: " + sessionId);
+        }
+
         const clock = this._platform.clock;
         this._sessionStartedByReconnector = false;
         this._status.set(LoadStatus.Loading);

--- a/src/matrix/Client.js
+++ b/src/matrix/Client.js
@@ -298,7 +298,7 @@ export class Client {
         }
 
         this._sync = this._platform.syncFactory.make({
-            scheduler: this._requestScheduler,
+            hsApi: this._requestScheduler.hsApi,
             storage: this._storage,
             session: this._session,
         });

--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -132,6 +132,14 @@ export class Session {
         return this._sessionInfo.userId;
     }
 
+    get homeserver() {
+        return this._sessionInfo.homeServer;
+    }
+
+    get accessToken() {
+        return this._sessionInfo.accessToken;
+    }
+
     get callHandler() {
         return this._callHandler;
     }

--- a/src/matrix/SessionFactory.ts
+++ b/src/matrix/SessionFactory.ts
@@ -1,0 +1,90 @@
+import {Session} from "./Session";
+import {Platform} from "../platform/web/Platform";
+import {Reconnector} from "./net/Reconnector";
+import {Storage} from "./storage/idb/Storage";
+import {HomeServerApi} from "./net/HomeServerApi";
+import {RequestScheduler} from "./net/RequestScheduler";
+import {MediaRepository} from "./net/MediaRepository";
+import {FeatureSet} from "../features";
+import type * as OlmNamespace from "@matrix-org/olm";
+import {OlmWorker} from "./e2ee/OlmWorker";
+type Olm = typeof OlmNamespace;
+
+type Options = {
+    platform: Platform,
+    features: FeatureSet,
+    reconnector: Reconnector,
+}
+
+type MakeOptions = {
+    storage: Storage,
+    olm: Olm | null,
+    olmWorker: OlmWorker | null,
+    sessionInfo: {
+        id: string,
+        deviceId: string,
+        userId: string,
+        homeServer: string,
+        accessToken: string,
+    },
+}
+
+type SessionAndScheduler = {
+    session: Session,
+    scheduler: RequestScheduler,
+}
+
+export class SessionFactory {
+    private readonly _platform: Platform;
+    private readonly _features: FeatureSet;
+    private readonly _reconnector: Reconnector;
+
+    constructor(options: Options) {
+        const {platform, features, reconnector} = options;
+        this._platform = platform;
+        this._features = features;
+        this._reconnector = reconnector;
+    }
+
+    make(options: MakeOptions): SessionAndScheduler {
+        const {sessionInfo, storage, olm, olmWorker} = options;
+
+        const hsApi = new HomeServerApi({
+            homeserver: sessionInfo.homeServer,
+            accessToken: sessionInfo.accessToken,
+            request: this._platform.request,
+            reconnector: this._reconnector,
+        });
+
+        const scheduler = new RequestScheduler({hsApi, clock: this._platform.clock});
+
+        const mediaRepository = new MediaRepository({
+            homeserver: sessionInfo.homeServer,
+            platform: this._platform,
+        });
+
+        // no need to pass access token to session
+        const filteredSessionInfo = {
+            id: sessionInfo.id,
+            deviceId: sessionInfo.deviceId,
+            userId: sessionInfo.userId,
+            homeserver: sessionInfo.homeServer,
+        };
+
+        const session = new Session({
+            platform: this._platform,
+            features: this._features,
+            storage: storage,
+            sessionInfo: filteredSessionInfo,
+            hsApi: scheduler.hsApi,
+            olm,
+            olmWorker,
+            mediaRepository,
+        });
+
+        return {
+            session: session,
+            scheduler: scheduler,
+        }
+    }
+}

--- a/src/matrix/SessionFactory.ts
+++ b/src/matrix/SessionFactory.ts
@@ -63,19 +63,11 @@ export class SessionFactory {
             platform: this._platform,
         });
 
-        // no need to pass access token to session
-        const filteredSessionInfo = {
-            id: sessionInfo.id,
-            deviceId: sessionInfo.deviceId,
-            userId: sessionInfo.userId,
-            homeserver: sessionInfo.homeServer,
-        };
-
         const session = new Session({
             platform: this._platform,
             features: this._features,
             storage: storage,
-            sessionInfo: filteredSessionInfo,
+            sessionInfo: sessionInfo,
             hsApi: scheduler.hsApi,
             olm,
             olmWorker,

--- a/src/matrix/net/Reconnector.ts
+++ b/src/matrix/net/Reconnector.ts
@@ -38,7 +38,7 @@ export class Reconnector {
     private readonly _createTimeMeasure: () => TimeMeasure;
     private readonly _onlineStatus: OnlineStatus;
     private readonly _state: ObservableValue<ConnectionStatus>;
-    private _isStarted = false;
+    private _isStarted: boolean;
     private _isReconnecting: boolean;
     private _versionsResponse?: VersionResponse;
     private _stateSince: TimeMeasure;
@@ -49,6 +49,7 @@ export class Reconnector {
         this._createTimeMeasure = createMeasure;
         // assume online, and do our thing when something fails
         this._state = new ObservableValue(ConnectionStatus.Online);
+        this._isStarted = false;
         this._isReconnecting = false;
     }
 

--- a/src/matrix/net/Reconnector.ts
+++ b/src/matrix/net/Reconnector.ts
@@ -38,6 +38,7 @@ export class Reconnector {
     private readonly _createTimeMeasure: () => TimeMeasure;
     private readonly _onlineStatus: OnlineStatus;
     private readonly _state: ObservableValue<ConnectionStatus>;
+    private _isStarted = false;
     private _isReconnecting: boolean;
     private _versionsResponse?: VersionResponse;
     private _stateSince: TimeMeasure;
@@ -66,8 +67,24 @@ export class Reconnector {
         return 0;
     }
 
+    get isStarted(): boolean {
+        return this._isStarted;
+    }
+
+    start(): void {
+        this._isStarted = true;
+    }
+
+    stop(): void {
+        this._isStarted = false;
+    }
+
     async onRequestFailed(hsApi: HomeServerApi): Promise<void> {
-        if (!this._isReconnecting) {  
+        if (!this._isStarted) {
+            return;
+        }
+
+        if (!this._isReconnecting) {
             this._isReconnecting = true;
  
             const onlineStatusSubscription = this._onlineStatus && this._onlineStatus.subscribe(online => {
@@ -114,7 +131,7 @@ export class Reconnector {
         this._versionsResponse = undefined;
         this._retryDelay.reset();
 
-        while (!this._versionsResponse) {
+        while (this._isStarted && !this._versionsResponse) {
             try {
                 this._setState(ConnectionStatus.Reconnecting);
                 // use 30s timeout, as a tradeoff between not giving up
@@ -165,6 +182,7 @@ export function tests() {
             const onlineStatus = new ObservableValue(false);
             const retryDelay = new _ExponentialRetryDelay(clock.createTimeout);
             const reconnector = new Reconnector({retryDelay, onlineStatus, createMeasure});
+            reconnector.start();
             const {connectionStatus} = reconnector;
             const statuses: ConnectionStatus[] = [];
             const subscription = reconnector.connectionStatus.subscribe(s => {
@@ -190,6 +208,7 @@ export function tests() {
             const onlineStatus = new ObservableValue(false);
             const retryDelay = new _ExponentialRetryDelay(clock.createTimeout);
             const reconnector = new Reconnector({retryDelay, onlineStatus, createMeasure});
+            reconnector.start();
             const {connectionStatus} = reconnector;
             // @ts-ignore
             reconnector.onRequestFailed(createHsApiMock(1));

--- a/src/matrix/storage/idb/StorageFactory.ts
+++ b/src/matrix/storage/idb/StorageFactory.ts
@@ -52,12 +52,12 @@ async function requestPersistedStorage(): Promise<boolean> {
 }
 
 export class StorageFactory {
-    private _serviceWorkerHandler: ServiceWorkerHandler;
+    private _serviceWorkerHandler?: ServiceWorkerHandler;
     private _idbFactory: IDBFactory;
     private _IDBKeyRange: typeof IDBKeyRange;
     private _localStorage: IDOMStorage;
 
-    constructor(serviceWorkerHandler: ServiceWorkerHandler, idbFactory: IDBFactory = window.indexedDB, _IDBKeyRange = window.IDBKeyRange, localStorage: IDOMStorage = window.localStorage) {
+    constructor(serviceWorkerHandler?: ServiceWorkerHandler, idbFactory: IDBFactory = self.indexedDB, _IDBKeyRange = self.IDBKeyRange, localStorage: IDOMStorage = self.localStorage) {
         this._serviceWorkerHandler = serviceWorkerHandler;
         this._idbFactory = idbFactory;
         this._IDBKeyRange = _IDBKeyRange;

--- a/src/platform/web/sync/SyncFactory.ts
+++ b/src/platform/web/sync/SyncFactory.ts
@@ -53,6 +53,11 @@ export class SyncFactory {
             runSyncInWorker = false;
         }
 
+        if (!window.WebAssembly) {
+            // Sync worker currently only supports Olm through Wasm.
+            runSyncInWorker = false;
+        }
+
         if (runSyncInWorker) {
             return new SyncProxy({session});
         }

--- a/src/platform/web/sync/SyncFactory.ts
+++ b/src/platform/web/sync/SyncFactory.ts
@@ -22,6 +22,7 @@ import {Logger} from "../../../logging/Logger";
 import {Storage} from "../../../matrix/storage/idb/Storage";
 import {FeatureSet} from "../../../features";
 import {SyncProxy} from "./SyncProxy";
+import {HomeServerApi} from "../../../matrix/net/HomeServerApi";
 
 type Options = {
     logger: Logger;
@@ -29,7 +30,7 @@ type Options = {
 }
 
 type MakeOptions = {
-    scheduler: RequestScheduler;
+    hsApi: HomeServerApi;
     storage: Storage;
     session: Session;
 }
@@ -45,7 +46,7 @@ export class SyncFactory {
     }
 
     make(options: MakeOptions): ISync {
-        const {scheduler, storage, session} = options;
+        const {hsApi, storage, session} = options;
         let runSyncInWorker = this._features.sameSessionInMultipleTabs;
 
         if (typeof SharedWorker === "undefined") {
@@ -58,7 +59,7 @@ export class SyncFactory {
 
         return new Sync({
             logger: this._logger,
-            hsApi: scheduler.hsApi,
+            hsApi: hsApi,
             storage,
             session,
         });

--- a/src/platform/web/sync/SyncProxy.ts
+++ b/src/platform/web/sync/SyncProxy.ts
@@ -71,6 +71,10 @@ export class SyncProxy implements ISync {
             type: SyncRequestType.StartSync,
             data: {
                 sessionId: this._session.sessionId,
+                deviceId: this._session.deviceId,
+                userId: this._session.userId,
+                homeserver: this._session.homeserver,
+                accessToken: this._session.accessToken,
             }
         };
 

--- a/src/platform/web/sync/make-worker.js
+++ b/src/platform/web/sync/make-worker.js
@@ -22,6 +22,5 @@ export function makeSyncWorker(name) {
     return new SharedWorker(new URL("../../workers/sync/sync-worker", import.meta.url), {
         /* @vite-ignore */
         name: name,
-        type: "module",
     });
 }

--- a/src/platform/workers/sync/SyncPlatform.ts
+++ b/src/platform/workers/sync/SyncPlatform.ts
@@ -1,0 +1,32 @@
+import {Clock} from "../../web/dom/Clock";
+import {RequestFunction} from "../../types/types";
+import {createFetchRequest} from "../../web/dom/request/fetch";
+
+// Same as Platform but only implements methods called by Sync.
+export class SyncPlatform {
+    private readonly _clock: Clock;
+    private _assetPaths: any;
+    private readonly _request: RequestFunction;
+
+    constructor({assetPaths}) {
+        this._assetPaths = assetPaths;
+        this._clock = new Clock;
+        this._request = createFetchRequest(this._clock.createTimeout);
+    }
+
+    loadOlm() {
+        return null;
+    }
+
+    async loadOlmWorker() {
+        return null;
+    }
+
+    get clock(): Clock {
+        return this._clock;
+    }
+
+    get request(): RequestFunction {
+        return this._request;
+    }
+}

--- a/src/platform/workers/sync/SyncPlatform.ts
+++ b/src/platform/workers/sync/SyncPlatform.ts
@@ -28,6 +28,7 @@ export class SyncPlatform {
     }
 
     async loadOlm(): Promise<Olm> {
+        // Mangle the globals enough to make olm believe it is running in a browser.
         // @ts-ignore
         self.window = self;
         // @ts-ignore

--- a/src/platform/workers/sync/SyncWorker.ts
+++ b/src/platform/workers/sync/SyncWorker.ts
@@ -9,11 +9,14 @@ import {OnlineStatus} from "../../web/dom/OnlineStatus";
 import {SessionFactory} from "../../../matrix/SessionFactory";
 import {FeatureSet} from "../../../features";
 import {StorageFactory} from "../../../matrix/storage/idb/StorageFactory";
+import {Logger} from "../../../logging/Logger";
+import {ConsoleReporter} from "../../../logging/ConsoleReporter";
 
 export class SyncWorker extends SharedWorker {
     private readonly _eventBus: BroadcastChannel;
     private readonly _platform: SyncPlatform;
     private readonly _features: FeatureSet;
+    private readonly _logger: Logger;
     private readonly _storageFactory: StorageFactory;
     private readonly _onlineStatus: OnlineStatus;
     private readonly _reconnector: Reconnector;
@@ -24,6 +27,8 @@ export class SyncWorker extends SharedWorker {
         this._eventBus = new BroadcastChannel(this.name);
         this._platform = new SyncPlatform({assetPaths});
         this._features = new FeatureSet;
+        this._logger = new Logger({platform: this._platform});
+        this._logger.addReporter(new ConsoleReporter());
         this._storageFactory = new StorageFactory;
         this._onlineStatus = new OnlineStatus;
         this._reconnector = new Reconnector({

--- a/src/platform/workers/sync/SyncWorker.ts
+++ b/src/platform/workers/sync/SyncWorker.ts
@@ -6,23 +6,33 @@ import assetPaths from "../../web/sdk/paths/vite";
 import {Reconnector} from "../../../matrix/net/Reconnector";
 import {ExponentialRetryDelay} from "../../../matrix/net/ExponentialRetryDelay";
 import {OnlineStatus} from "../../web/dom/OnlineStatus";
+import {SessionFactory} from "../../../matrix/SessionFactory";
+import {FeatureSet} from "../../../features";
 
 export class SyncWorker extends SharedWorker {
     private readonly _eventBus: BroadcastChannel;
     private readonly _platform: SyncPlatform;
+    private readonly _features: FeatureSet;
     private readonly _onlineStatus: OnlineStatus;
     private readonly _reconnector: Reconnector;
+    private readonly _sessionFactory: SessionFactory;
 
     constructor() {
         super();
         this._eventBus = new BroadcastChannel(this.name);
         this._platform = new SyncPlatform({assetPaths});
+        this._features = new FeatureSet;
         this._onlineStatus = new OnlineStatus;
         this._reconnector = new Reconnector({
             onlineStatus: this._onlineStatus,
             retryDelay: new ExponentialRetryDelay(this._platform.clock.createTimeout),
             createMeasure: this._platform.clock.createMeasure
         });
+        this._sessionFactory = new SessionFactory({
+            platform: this._platform,
+            features: this._features,
+            reconnector: this._reconnector,
+        })
 
         this.setHandler(SyncRequestType.StartSync, this.startSync.bind(this));
     }

--- a/src/platform/workers/sync/SyncWorker.ts
+++ b/src/platform/workers/sync/SyncWorker.ts
@@ -8,11 +8,13 @@ import {ExponentialRetryDelay} from "../../../matrix/net/ExponentialRetryDelay";
 import {OnlineStatus} from "../../web/dom/OnlineStatus";
 import {SessionFactory} from "../../../matrix/SessionFactory";
 import {FeatureSet} from "../../../features";
+import {StorageFactory} from "../../../matrix/storage/idb/StorageFactory";
 
 export class SyncWorker extends SharedWorker {
     private readonly _eventBus: BroadcastChannel;
     private readonly _platform: SyncPlatform;
     private readonly _features: FeatureSet;
+    private readonly _storageFactory: StorageFactory;
     private readonly _onlineStatus: OnlineStatus;
     private readonly _reconnector: Reconnector;
     private readonly _sessionFactory: SessionFactory;
@@ -22,6 +24,7 @@ export class SyncWorker extends SharedWorker {
         this._eventBus = new BroadcastChannel(this.name);
         this._platform = new SyncPlatform({assetPaths});
         this._features = new FeatureSet;
+        this._storageFactory = new StorageFactory;
         this._onlineStatus = new OnlineStatus;
         this._reconnector = new Reconnector({
             onlineStatus: this._onlineStatus,

--- a/src/platform/workers/sync/SyncWorker.ts
+++ b/src/platform/workers/sync/SyncWorker.ts
@@ -1,13 +1,18 @@
 import {SharedWorker} from "../SharedWorker";
 import {StartSyncRequest, StartSyncResponse, SyncEvent, SyncRequestType, SyncStatusChanged} from "../types/sync";
 import {Event, makeEventId} from "../types/base";
+import {SyncPlatform} from "./SyncPlatform";
+import assetPaths from "../../web/sdk/paths/vite";
 
 export class SyncWorker extends SharedWorker {
     private readonly _eventBus: BroadcastChannel;
+    private readonly _platform: SyncPlatform;
 
     constructor() {
         super();
         this._eventBus = new BroadcastChannel(this.name);
+        this._platform = new SyncPlatform({assetPaths});
+
         this.setHandler(SyncRequestType.StartSync, this.startSync.bind(this));
     }
 

--- a/src/platform/workers/sync/sync-worker.ts
+++ b/src/platform/workers/sync/sync-worker.ts
@@ -15,7 +15,19 @@ limitations under the License.
 */
 
 import {SyncWorker} from "./SyncWorker";
+import assetPaths from "../../web/sdk/paths/vite";
 
 declare const self;
 
-self.syncWorker = new SyncWorker();
+// Vite makes the paths relative (e.g. ./assets/olm.abc123.js) but we want the absolute path, so we strip the
+// leading `.`.
+// TODO: Fix this at vite level.
+const olmWasmJsPath = assetPaths.olm.wasmBundle.substring(1);
+const olmWasmPath = assetPaths.olm.wasm.substring(1);
+
+self.syncWorker = new SyncWorker({
+    assets: {
+        olmWasmJsPath: olmWasmJsPath,
+        olmWasmPath: olmWasmPath,
+    }
+});

--- a/src/platform/workers/types/sync.ts
+++ b/src/platform/workers/types/sync.ts
@@ -12,6 +12,10 @@ export interface StartSyncRequest extends Request {
     type: SyncRequestType.StartSync;
     data: {
         sessionId: string,
+        deviceId: string,
+        userId: string,
+        homeserver: string,
+        accessToken: string,
     }
 }
 export interface StartSyncResponse extends Response {


### PR DESCRIPTION
This PR makes sync successfully run in a worker, including olm decryption. Note that sync changes are not yet communicated to the UI, that will be done in a future PR.

## Summary of changes
1. Extract logic for creating an instance of `Session` out of `Client` and into a `SessionFactory`, so that it can be reused.
2. Add `SyncPlatform`, which is equivalent to `Platform`, but only defines methods necessary to run sync.
3. Use `SessionFactory` to make an instance of `Session` in worker.
4. Load session and start sync in worker.
5. Load Olm (WebAssembly version) in worker.

## Screenshot

<img width="492" alt="Screenshot 2023-03-23 at 14 56 23" src="https://user-images.githubusercontent.com/550401/227243507-5a1a1a93-b61a-4f9f-bcf3-11c34037a6c4.png">
