### PR TITLE
Broadcast session and room changes from sync worker (no encryption yet)

### DIFF
--- a/src/matrix/SendQueuePool.ts
+++ b/src/matrix/SendQueuePool.ts
@@ -28,4 +28,8 @@ export class SendQueuePool extends EventEmitter<any> {
         this._queues.set(roomId, sendQueue);
         return sendQueue;
     }
+
+    getQueue(roomId: RoomId): SendQueue | undefined {
+        return this._queues.get(roomId);
+    }
 }

--- a/src/matrix/SendQueuePool.ts
+++ b/src/matrix/SendQueuePool.ts
@@ -1,0 +1,30 @@
+import {SendQueue} from "./room/sending/SendQueue";
+import {EventEmitter} from "../utils/EventEmitter";
+import {HomeServerApi} from "./net/HomeServerApi";
+import {Storage} from "./storage/idb/Storage";
+
+type RoomId = string;
+
+type Options = {
+    storage: Storage,
+    hsApi: HomeServerApi,
+}
+
+export class SendQueuePool extends EventEmitter<any> {
+    private readonly _queues: Map<RoomId, SendQueue> = new Map;
+    private readonly _storage: Storage;
+    private readonly _hsApi: HomeServerApi;
+
+    constructor(options: Options) {
+        super();
+        const {storage, hsApi} = options;
+        this._storage = storage;
+        this._hsApi = hsApi;
+    }
+
+    createQueue(roomId: RoomId, pendingEvents: []): SendQueue {
+        const sendQueue = new SendQueue({roomId, storage: this._storage, hsApi: this._hsApi, pendingEvents});
+        this._queues.set(roomId, sendQueue);
+        return sendQueue;
+    }
+}

--- a/src/matrix/SendQueuePool.ts
+++ b/src/matrix/SendQueuePool.ts
@@ -24,6 +24,7 @@ export class SendQueuePool extends EventEmitter<any> {
 
     createQueue(roomId: RoomId, pendingEvents: []): SendQueue {
         const sendQueue = new SendQueue({roomId, storage: this._storage, hsApi: this._hsApi, pendingEvents});
+        sendQueue.on("pendingEvent", event => this.emit("pendingEvent", event));
         this._queues.set(roomId, sendQueue);
         return sendQueue;
     }

--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -49,6 +49,7 @@ import {SecretStorage} from "./ssss/SecretStorage";
 import {ObservableValue, RetainedObservableValue} from "../observable/value";
 import {CallHandler} from "./calls/CallHandler";
 import {RoomStateHandlerSet} from "./room/state/RoomStateHandlerSet";
+import {SendQueue} from "./room/sending/SendQueue";
 
 const PICKLE_KEY = "DEFAULT_KEY";
 const PUSHER_KEY = "pusher";
@@ -633,6 +634,7 @@ export class Session {
 
     /** @internal */
     createJoinedRoom(roomId, pendingEvents) {
+        const sendQueue = new SendQueue({roomId, storage: this._storage, hsApi: this._hsApi, pendingEvents});
         return new Room({
             roomId,
             getSyncToken: this._getSyncToken,
@@ -644,7 +646,8 @@ export class Session {
             user: this._user,
             createRoomEncryption: this._createRoomEncryption,
             platform: this._platform,
-            roomStateHandler: this._roomStateHandler
+            roomStateHandler: this._roomStateHandler,
+            sendQueue
         });
     }
 

--- a/src/matrix/SessionFactory.ts
+++ b/src/matrix/SessionFactory.ts
@@ -8,6 +8,7 @@ import {MediaRepository} from "./net/MediaRepository";
 import {FeatureSet} from "../features";
 import type * as OlmNamespace from "@matrix-org/olm";
 import {OlmWorker} from "./e2ee/OlmWorker";
+import {SendQueuePool} from "./SendQueuePool";
 type Olm = typeof OlmNamespace;
 
 type Options = {
@@ -63,6 +64,8 @@ export class SessionFactory {
             platform: this._platform,
         });
 
+        const sendQueuePool = new SendQueuePool({storage, hsApi});
+
         const session = new Session({
             platform: this._platform,
             features: this._features,
@@ -72,6 +75,7 @@ export class SessionFactory {
             olm,
             olmWorker,
             mediaRepository,
+            sendQueuePool
         });
 
         return {

--- a/src/matrix/Sync.js
+++ b/src/matrix/Sync.js
@@ -452,7 +452,7 @@ export class Sync {
     }
 }
 
-class SessionSyncProcessState {
+export class SessionSyncProcessState {
     constructor() {
         this.lock = null;
         this.preparation = null;
@@ -464,7 +464,7 @@ class SessionSyncProcessState {
     }
 }
 
-class RoomSyncProcessState {
+export class RoomSyncProcessState {
     constructor(room, isNewRoom, roomResponse, membership) {
         this.room = room;
         this.isNewRoom = isNewRoom;
@@ -492,7 +492,7 @@ class RoomSyncProcessState {
 }
 
 
-class ArchivedRoomSyncProcessState {
+export class ArchivedRoomSyncProcessState {
     constructor(archivedRoom, roomState, roomResponse, membership, isInitialSync) {
         this.archivedRoom = archivedRoom;
         this.roomState = roomState;
@@ -515,7 +515,7 @@ class ArchivedRoomSyncProcessState {
     }
 }
 
-class InviteSyncProcessState {
+export class InviteSyncProcessState {
     constructor(invite, isNewInvite, roomResponse, membership) {
         this.invite = invite;
         this.isNewInvite = isNewInvite;

--- a/src/matrix/room/Room.js
+++ b/src/matrix/room/Room.js
@@ -32,8 +32,7 @@ export class Room extends BaseRoom {
     constructor(options) {
         super(options);
         this._roomStateHandler = options.roomStateHandler;
-        // TODO: pass pendingEvents to start like pendingOperations?
-        const {pendingEvents} = options;
+        this._sendQueue = options.sendQueue;
         const relationWriter = new RelationWriter({
             roomId: this.id,
             fragmentIdComparer: this._fragmentIdComparer,
@@ -45,7 +44,6 @@ export class Room extends BaseRoom {
             relationWriter,
             memberWriter: new MemberWriter(this.id)
         });
-        this._sendQueue = new SendQueue({roomId: this.id, storage: this._storage, hsApi: this._hsApi, pendingEvents});
     }
 
     _setEncryption(roomEncryption) {

--- a/src/matrix/room/Room.js
+++ b/src/matrix/room/Room.js
@@ -54,6 +54,10 @@ export class Room extends BaseRoom {
         return false;
     }
 
+    get sendQueue() {
+        return this._sendQueue;
+    }
+
     async prepareSync(roomResponse, membership, newKeys, txn, log) {
         log.set("id", this.id);
         if (newKeys) {

--- a/src/matrix/room/members/RoomMember.js
+++ b/src/matrix/room/members/RoomMember.js
@@ -71,6 +71,10 @@ export class RoomMember {
         });
     }
 
+    get data() {
+        return this._data;
+    }
+
     get membership() {
         return this._data.membership;
     }

--- a/src/matrix/room/sending/SendQueue.js
+++ b/src/matrix/room/sending/SendQueue.js
@@ -20,9 +20,11 @@ import {PendingEvent, SendStatus} from "./PendingEvent.js";
 import {makeTxnId, isTxnId} from "../../common.js";
 import {REDACTION_TYPE} from "../common";
 import {getRelationFromContent, getRelationTarget, setRelationTarget, REACTION_TYPE, ANNOTATION_RELATION_TYPE} from "../timeline/relations.js";
+import {EventEmitter} from "../../../utils/EventEmitter";
 
-export class SendQueue {
+export class SendQueue extends EventEmitter {
     constructor({roomId, storage, hsApi, pendingEvents}) {
+        super();
         pendingEvents = pendingEvents || [];
         this._roomId = roomId;
         this._storage = storage;
@@ -231,6 +233,7 @@ export class SendQueue {
     async _enqueueEvent(eventType, content, attachments, relatedTxnId, relatedEventId, log) {
         const pendingEvent = await this._createAndStoreEvent(eventType, content, relatedTxnId, relatedEventId, attachments);
         this._pendingEvents.set(pendingEvent);
+        this.emit("pendingEvent", pendingEvent);
         log.set("queueIndex", pendingEvent.queueIndex);
         log.set("pendingEvents", this._pendingEvents.length);
         if (!this._isSending && !this._offline) {

--- a/src/matrix/room/sending/SendQueue.js
+++ b/src/matrix/room/sending/SendQueue.js
@@ -37,6 +37,10 @@ export class SendQueue extends EventEmitter {
         this._currentQueueIndex = 0;
     }
 
+    addExistingPendingEvent(eventData) {
+        this._pendingEvents.set(this._createPendingEvent(eventData));
+    }
+
     _createPendingEvent(data, attachments = null) {
         const pendingEvent = new PendingEvent({
             data,

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -44,6 +44,10 @@ export class EventEntry extends BaseEventEntry {
         this._contextEntry = other.contextEntry;
     }
 
+    get data() {
+        return this._eventEntry;
+    }
+
     get event() {
         return this._eventEntry.event;
     }

--- a/src/platform/web/sync/SyncFactory.ts
+++ b/src/platform/web/sync/SyncFactory.ts
@@ -59,7 +59,7 @@ export class SyncFactory {
         }
 
         if (runSyncInWorker) {
-            return new SyncProxy({session});
+            return new SyncProxy({session, logger: this._logger});
         }
 
         return new Sync({

--- a/src/platform/web/sync/SyncProxy.ts
+++ b/src/platform/web/sync/SyncProxy.ts
@@ -96,9 +96,6 @@ export class SyncProxy implements ISync {
         if (response?.error) {
             throw response.error;
         }
-
-        // TODO
-        console.log(response);
     }
 
     stop(): void {

--- a/src/platform/web/sync/SyncProxy.ts
+++ b/src/platform/web/sync/SyncProxy.ts
@@ -29,9 +29,11 @@ import {
 import {WorkerProxy} from "../worker/WorkerProxy";
 import {EventBus} from "../worker/EventBus";
 import {makeRequestId} from "../../workers/types/base";
+import {Logger} from "../../../logging/Logger";
 
 type Options = {
     session: Session;
+    logger: Logger,
 }
 
 export class SyncProxy implements ISync {
@@ -39,11 +41,13 @@ export class SyncProxy implements ISync {
     private readonly _workerProxy: WorkerProxy;
     private readonly _eventBus: EventBus;
     private readonly _status: ObservableValue<SyncStatus> = new ObservableValue(SyncStatus.Stopped);
+    private readonly _logger: Logger;
     private _error: Error | null = null;
 
     constructor(options: Options) {
-        const {session} = options;
+        const {session, logger} = options;
         this._session = session;
+        this._logger = logger;
 
         const sessionId = this._session.sessionId;
         if (!sessionId) {

--- a/src/platform/web/sync/SyncProxy.ts
+++ b/src/platform/web/sync/SyncProxy.ts
@@ -142,6 +142,11 @@ export class SyncProxy implements ISync {
 
                     const room = rooms.get(roomId);
                     const deserializedRoomChanges = deserializeRoomChanges(room, roomChanges);
+
+                    room.sendQueue.removePendingEvents(deserializedRoomChanges.changes.removedPendingEvents);
+                    // We already remove pending events, so we don't want room.afterSync() to try to remove them again.
+                    // So we set the removedPendingEvents array to empty.
+                    deserializedRoomChanges.changes.removedPendingEvents = [];
                     room.afterSync(deserializedRoomChanges.changes, log);
                 }
             });

--- a/src/platform/web/sync/SyncProxy.ts
+++ b/src/platform/web/sync/SyncProxy.ts
@@ -22,6 +22,7 @@ import {makeSyncWorker} from "./make-worker";
 import {
     StartSyncRequest,
     StartSyncResponse,
+    SyncChanges,
     SyncEvent,
     SyncRequestType,
     SyncStatusChanged
@@ -59,6 +60,7 @@ export class SyncProxy implements ISync {
         this._workerProxy = new WorkerProxy(makeSyncWorker(workerId) as SharedWorker);
         this._eventBus = new EventBus(workerId);
         this._eventBus.setListener(SyncEvent.StatusChanged, this.onStatusChanged.bind(this));
+        this._eventBus.setListener(SyncEvent.SyncChanges, this.onSyncChanges.bind(this));
     }
 
     get status(): ObservableValue<SyncStatus> {
@@ -97,5 +99,9 @@ export class SyncProxy implements ISync {
 
     private onStatusChanged(event: SyncStatusChanged): void {
         this._status.set(event.data.newValue);
+    }
+
+    private async onSyncChanges(event: SyncChanges): Promise<void> {
+        // TODO
     }
 }

--- a/src/platform/web/sync/SyncProxy.ts
+++ b/src/platform/web/sync/SyncProxy.ts
@@ -102,6 +102,13 @@ export class SyncProxy implements ISync {
     }
 
     private async onSyncChanges(event: SyncChanges): Promise<void> {
-        // TODO
+        const sessionChanges = event.data.session;
+
+        await this._logger.run("sync changes", async log => {
+            await log.wrap("session", log => {
+                log.log({l: "changes", ...sessionChanges});
+                this._session.afterSync(sessionChanges, log);
+            });
+        });
     }
 }

--- a/src/platform/web/worker/EventBus.ts
+++ b/src/platform/web/worker/EventBus.ts
@@ -19,12 +19,12 @@ export class EventBus {
         this._listeners.set(type, listener);
     }
 
-    onMessage(message: MessageEvent) {
+    async onMessage(message: MessageEvent) {
         const event = message.data as Event;
         const listener = this._listeners.get(event.type);
         if (!listener) {
             return;
         }
-        listener(event);
+        await listener(event);
     }
 }

--- a/src/platform/workers/sync/SyncInWorker.ts
+++ b/src/platform/workers/sync/SyncInWorker.ts
@@ -1,4 +1,11 @@
-import {Sync, SyncStatus} from "../../../matrix/Sync";
+import {
+    ArchivedRoomSyncProcessState,
+    InviteSyncProcessState,
+    RoomSyncProcessState,
+    SessionSyncProcessState,
+    Sync,
+    SyncStatus
+} from "../../../matrix/Sync";
 import {Logger} from "../../../logging/Logger";
 import {HomeServerApi} from "../../../matrix/net/HomeServerApi";
 import {Session} from "../../../matrix/Session";
@@ -28,5 +35,15 @@ export class SyncInWorker extends Sync {
 
     get status(): ObservableValue<SyncStatus> {
         return super.status;
+    }
+
+    _afterSync(
+        sessionState: SessionSyncProcessState,
+        inviteStates: InviteSyncProcessState[],
+        roomStates: RoomSyncProcessState[],
+        archivedRoomStates: ArchivedRoomSyncProcessState[],
+        log
+    ) {
+        super._afterSync(sessionState, inviteStates, roomStates, archivedRoomStates, log);
     }
 }

--- a/src/platform/workers/sync/SyncInWorker.ts
+++ b/src/platform/workers/sync/SyncInWorker.ts
@@ -1,8 +1,9 @@
-import {Sync} from "../../../matrix/Sync";
+import {Sync, SyncStatus} from "../../../matrix/Sync";
 import {Logger} from "../../../logging/Logger";
 import {HomeServerApi} from "../../../matrix/net/HomeServerApi";
 import {Session} from "../../../matrix/Session";
 import {Storage} from "../../../matrix/storage/idb/Storage";
+import {ObservableValue} from "../../../observable/value";
 
 type Options = {
     logger: Logger,
@@ -23,5 +24,9 @@ export class SyncInWorker extends Sync {
 
     async start() {
         return super.start();
+    }
+
+    get status(): ObservableValue<SyncStatus> {
+        return super.status;
     }
 }

--- a/src/platform/workers/sync/SyncInWorker.ts
+++ b/src/platform/workers/sync/SyncInWorker.ts
@@ -11,6 +11,8 @@ import {HomeServerApi} from "../../../matrix/net/HomeServerApi";
 import {Session} from "../../../matrix/Session";
 import {Storage} from "../../../matrix/storage/idb/Storage";
 import {ObservableValue} from "../../../observable/value";
+import {SessionChanges, SyncChanges, SyncEvent} from "../types/sync";
+import {makeEventId} from "../types/base";
 
 type Options = {
     logger: Logger,
@@ -45,5 +47,20 @@ export class SyncInWorker extends Sync {
         log
     ) {
         super._afterSync(sessionState, inviteStates, roomStates, archivedRoomStates, log);
+        this.sendSyncChangesEvent(
+            sessionState.changes
+        );
+    }
+
+    private sendSyncChangesEvent(sessionChanges: SessionChanges)
+    {
+        const event: SyncChanges = {
+            type: SyncEvent.SyncChanges,
+            id: makeEventId(),
+            data: {
+                session: sessionChanges,
+            }
+        }
+        this._eventBus.postMessage(event);
     }
 }

--- a/src/platform/workers/sync/SyncInWorker.ts
+++ b/src/platform/workers/sync/SyncInWorker.ts
@@ -1,0 +1,27 @@
+import {Sync} from "../../../matrix/Sync";
+import {Logger} from "../../../logging/Logger";
+import {HomeServerApi} from "../../../matrix/net/HomeServerApi";
+import {Session} from "../../../matrix/Session";
+import {Storage} from "../../../matrix/storage/idb/Storage";
+
+type Options = {
+    logger: Logger,
+    hsApi: HomeServerApi,
+    session: Session,
+    storage: Storage,
+    eventBus: BroadcastChannel,
+}
+
+export class SyncInWorker extends Sync {
+    private _eventBus: BroadcastChannel;
+
+    constructor(options: Options) {
+        const {eventBus, ...baseOptions} = options;
+        super(baseOptions);
+        this._eventBus = eventBus;
+    }
+
+    async start() {
+        return super.start();
+    }
+}

--- a/src/platform/workers/sync/SyncWorker.ts
+++ b/src/platform/workers/sync/SyncWorker.ts
@@ -13,7 +13,7 @@ import {Logger} from "../../../logging/Logger";
 import {ConsoleReporter} from "../../../logging/ConsoleReporter";
 import {Storage} from "../../../matrix/storage/idb/Storage";
 import {RequestScheduler} from "../../../matrix/net/RequestScheduler";
-import {Sync} from "../../../matrix/Sync";
+import {SyncInWorker} from "./SyncInWorker";
 
 type Assets = {
     olmWasmJsPath: string,
@@ -36,7 +36,7 @@ export class SyncWorker extends SharedWorker {
     private _session?: Session;
     private _storage?: Storage;
     private _scheduler?: RequestScheduler;
-    private _sync?: Sync;
+    private _sync?: SyncInWorker;
 
     constructor(options: Options) {
         super();
@@ -79,14 +79,15 @@ export class SyncWorker extends SharedWorker {
         this._storage = storage;
         this._scheduler = scheduler;
 
-        this._sync = new Sync({
+        this._sync = new SyncInWorker({
             logger: this._logger,
             hsApi: this._scheduler.hsApi,
             session: this._session,
             storage: this._storage,
+            eventBus: this._eventBus,
         })
 
-        this._sync.start();
+        await this._sync.start();
 
         const event: SyncStatusChanged = {
             id: makeEventId(),

--- a/src/platform/workers/sync/SyncWorker.ts
+++ b/src/platform/workers/sync/SyncWorker.ts
@@ -87,18 +87,22 @@ export class SyncWorker extends SharedWorker {
             eventBus: this._eventBus,
         })
 
+        this._sync.status.subscribe(this.onSyncStatusChanged.bind(this));
+
         await this._sync.start();
 
+        return response;
+    }
+
+    private onSyncStatusChanged() {
         const event: SyncStatusChanged = {
             id: makeEventId(),
             type: SyncEvent.StatusChanged,
             data: {
-                newValue: "Stopped",
+                newValue: this._sync?.status.get(),
             }
         }
         this.broadcastEvent(event);
-
-        return response;
     }
 
     broadcastEvent(event: Event) {

--- a/src/platform/workers/sync/serialize.ts
+++ b/src/platform/workers/sync/serialize.ts
@@ -1,0 +1,107 @@
+import {RoomChanges, SessionChanges} from "../types/sync";
+import {type Room} from "../../../matrix/room/Room";
+import {EventEntry} from "../../../matrix/room/timeline/entries/EventEntry";
+import {MemberChange, RoomMember} from "../../../matrix/room/members/RoomMember";
+import {type DecryptionResult} from "../../../matrix/e2ee/DecryptionResult";
+import {EventKey} from "../../../matrix/room/timeline/EventKey";
+
+type InMemorySessionSyncState = {
+    changes: {
+        syncInfo: {
+            token: string,
+            filterId: string,
+        },
+        hasNewRoomKeys: boolean,
+        e2eeAccountChanges?: number,
+        deviceMessageDecryptionResults: DecryptionResult[]|null,
+    }
+}
+
+type InMemoryRoomSyncState = {
+    room: Room,
+    changes: {
+        roomResponse: object,
+        newEntries: EventEntry[],
+        updatedEntries: EventEntry[],
+        memberChanges: Map<string, MemberChange>,
+        newLiveKey: EventKey,
+        summaryChanges: object,
+        heroChanges: object,
+        powerLevelsEvent: object,
+    }
+}
+
+export function serializeSessionChanges(sessionState: InMemorySessionSyncState): SessionChanges {
+    return sessionState.changes;
+}
+
+export function deserializeSessionChanges(sessionChanges: SessionChanges): InMemorySessionSyncState {
+    return {
+        changes: sessionChanges,
+    }
+}
+
+export function serializeRoomChanges(roomState: InMemoryRoomSyncState): RoomChanges {
+    const {room, changes} = roomState;
+    const {roomResponse, summaryChanges, heroChanges, powerLevelsEvent} = changes;
+    const newEntries = changes.newEntries.map((entry: EventEntry) => entry.data);
+    const updatedEntries = changes.updatedEntries.map((entry: EventEntry) => entry.data);
+
+    const memberChanges = new Map<string, { member: object, previousMembership: string }>;
+    for (let [key, mc] of changes.memberChanges) {
+        const {member, previousMembership} = mc;
+        memberChanges.set(key, {member: member.data, previousMembership});
+    }
+
+    const newLiveKey = {
+        fragmentId: changes.newLiveKey.fragmentId,
+        eventIndex: changes.newLiveKey.eventIndex,
+    }
+
+    return {
+        roomId: room.id,
+        changes: {
+            roomResponse,
+            newEntries,
+            updatedEntries,
+            memberChanges,
+            newLiveKey,
+            summaryChanges,
+            heroChanges,
+            powerLevelsEvent,
+        }
+    }
+}
+
+export function deserializeRoomChanges(room: Room, roomChanges: RoomChanges): InMemoryRoomSyncState {
+    const {changes} = roomChanges;
+    const {roomResponse, newEntries, updatedEntries, memberChanges, newLiveKey} = changes;
+
+    const deserializedNewEntries = newEntries.map(entry => new EventEntry(entry, room._fragmentIdComparer));
+    const deserializedUpdatedEntries = updatedEntries.map(entry => new EventEntry(entry, room._fragmentIdComparer));
+
+    const deserializedMemberChanges = new Map<string, MemberChange>;
+    for (let [key, mc] of memberChanges) {
+        deserializedMemberChanges.set(key, new MemberChange(new RoomMember(mc.member), mc.previousMembership))
+    }
+
+    const deserializedNewLiveKey = new EventKey(newLiveKey.fragmentId, newLiveKey.eventIndex);
+
+    const deserializedSummaryChanges = changes.summaryChanges;
+    const deserializedHeroChanges = changes.heroChanges;
+    const deserializedPowerLevelsEvent = changes.powerLevelsEvent;
+
+    return {
+        room,
+        changes: {
+            roomResponse,
+            newEntries: deserializedNewEntries,
+            updatedEntries: deserializedUpdatedEntries,
+            memberChanges: deserializedMemberChanges,
+            newLiveKey: deserializedNewLiveKey,
+            summaryChanges: deserializedSummaryChanges,
+            heroChanges: deserializedHeroChanges,
+            powerLevelsEvent: deserializedPowerLevelsEvent,
+        }
+    };
+}

--- a/src/platform/workers/sync/serialize.ts
+++ b/src/platform/workers/sync/serialize.ts
@@ -4,6 +4,7 @@ import {EventEntry} from "../../../matrix/room/timeline/entries/EventEntry";
 import {MemberChange, RoomMember} from "../../../matrix/room/members/RoomMember";
 import {type DecryptionResult} from "../../../matrix/e2ee/DecryptionResult";
 import {EventKey} from "../../../matrix/room/timeline/EventKey";
+import {PendingEvent} from "../../../matrix/room/sending/PendingEvent";
 
 type InMemorySessionSyncState = {
     changes: {
@@ -28,6 +29,7 @@ type InMemoryRoomSyncState = {
         summaryChanges: object,
         heroChanges: object,
         powerLevelsEvent: object,
+        removedPendingEvents: PendingEvent[],
     }
 }
 
@@ -46,6 +48,7 @@ export function serializeRoomChanges(roomState: InMemoryRoomSyncState): RoomChan
     const {roomResponse, summaryChanges, heroChanges, powerLevelsEvent} = changes;
     const newEntries = changes.newEntries.map((entry: EventEntry) => entry.data);
     const updatedEntries = changes.updatedEntries.map((entry: EventEntry) => entry.data);
+    const removedPendingEvents = changes.removedPendingEvents.map((event: PendingEvent) => event.data);
 
     const memberChanges = new Map<string, { member: object, previousMembership: string }>;
     for (let [key, mc] of changes.memberChanges) {
@@ -69,13 +72,14 @@ export function serializeRoomChanges(roomState: InMemoryRoomSyncState): RoomChan
             summaryChanges,
             heroChanges,
             powerLevelsEvent,
+            removedPendingEvents,
         }
     }
 }
 
 export function deserializeRoomChanges(room: Room, roomChanges: RoomChanges): InMemoryRoomSyncState {
     const {changes} = roomChanges;
-    const {roomResponse, newEntries, updatedEntries, memberChanges, newLiveKey} = changes;
+    const {roomResponse, newEntries, updatedEntries, memberChanges, newLiveKey, removedPendingEvents} = changes;
 
     const deserializedNewEntries = newEntries.map(entry => new EventEntry(entry, room._fragmentIdComparer));
     const deserializedUpdatedEntries = updatedEntries.map(entry => new EventEntry(entry, room._fragmentIdComparer));
@@ -102,6 +106,7 @@ export function deserializeRoomChanges(room: Room, roomChanges: RoomChanges): In
             summaryChanges: deserializedSummaryChanges,
             heroChanges: deserializedHeroChanges,
             powerLevelsEvent: deserializedPowerLevelsEvent,
+            removedPendingEvents,
         }
     };
 }

--- a/src/platform/workers/types/sync.ts
+++ b/src/platform/workers/types/sync.ts
@@ -77,9 +77,9 @@ export type RoomChanges = {
         summaryChanges: object,
         heroChanges: object,
         powerLevelsEvent: object,
+        removedPendingEvents: object[],
 
         // TODO from below here
-        // removedPendingEvents,
         // roomEncryption,
         // encryptionChanges,
     }

--- a/src/platform/workers/types/sync.ts
+++ b/src/platform/workers/types/sync.ts
@@ -1,5 +1,5 @@
 import {Request, Response, Event} from "./base";
-import {DecryptionResult} from "../../../matrix/e2ee/DecryptionResult";
+import {type DecryptionResult} from "../../../matrix/e2ee/DecryptionResult";
 
 //
 // Requests/Responses
@@ -7,6 +7,7 @@ import {DecryptionResult} from "../../../matrix/e2ee/DecryptionResult";
 
 export enum SyncRequestType {
     StartSync = "StartSync",
+    AddPendingEvent = "AddPendingEvent",
 }
 
 export interface StartSyncRequest extends Request {
@@ -21,6 +22,17 @@ export interface StartSyncRequest extends Request {
 }
 export interface StartSyncResponse extends Response {
     request: StartSyncRequest;
+    data: {}
+}
+
+export interface AddPendingEventRequest extends Request {
+    type: SyncRequestType.AddPendingEvent;
+    data: {
+        pendingEvent: object, // TODO: Specify structure of this object.
+    }
+}
+export interface AddPendingEventResponse extends Response {
+    request: AddPendingEventRequest;
     data: {}
 }
 

--- a/src/platform/workers/types/sync.ts
+++ b/src/platform/workers/types/sync.ts
@@ -1,4 +1,5 @@
 import {Request, Response, Event} from "./base";
+import {DecryptionResult} from "../../../matrix/e2ee/DecryptionResult";
 
 //
 // Requests/Responses
@@ -29,11 +30,27 @@ export interface StartSyncResponse extends Response {
 
 export enum SyncEvent {
     StatusChanged = "StatusChanged",
+    SyncChanges = "SyncChanges",
 }
 
 export interface SyncStatusChanged extends Event {
     type: SyncEvent.StatusChanged;
     data: {
         newValue: string,
+    }
+}
+
+export interface SyncChanges extends Event {
+    type: SyncEvent.SyncChanges;
+    data: {
+        session: {
+            syncInfo: {
+                token: string,
+                filterId: string,
+            },
+            hasNewRoomKeys: boolean,
+            e2eeAccountChanges?: number,
+            deviceMessageDecryptionResults: DecryptionResult[]|null,
+        },
     }
 }

--- a/src/platform/workers/types/sync.ts
+++ b/src/platform/workers/types/sync.ts
@@ -40,17 +40,19 @@ export interface SyncStatusChanged extends Event {
     }
 }
 
+export type SessionChanges = {
+    syncInfo: {
+        token: string,
+        filterId: string,
+    },
+    hasNewRoomKeys: boolean,
+    e2eeAccountChanges?: number,
+    deviceMessageDecryptionResults: DecryptionResult[]|null,
+}
+
 export interface SyncChanges extends Event {
     type: SyncEvent.SyncChanges;
     data: {
-        session: {
-            syncInfo: {
-                token: string,
-                filterId: string,
-            },
-            hasNewRoomKeys: boolean,
-            e2eeAccountChanges?: number,
-            deviceMessageDecryptionResults: DecryptionResult[]|null,
-        },
+        session: SessionChanges,
     }
 }

--- a/src/platform/workers/types/sync.ts
+++ b/src/platform/workers/types/sync.ts
@@ -62,9 +62,33 @@ export type SessionChanges = {
     deviceMessageDecryptionResults: DecryptionResult[]|null,
 }
 
+export type RoomChanges = {
+    roomId: string,
+    changes: {
+        // TODO: Specify structure of below objects.
+        roomResponse: object,
+        newEntries: object[],
+        updatedEntries: object[],
+        memberChanges: Map<string, { member: object, previousMembership: string }>,
+        newLiveKey: {
+            fragmentId: number,
+            eventIndex: number,
+        },
+        summaryChanges: object,
+        heroChanges: object,
+        powerLevelsEvent: object,
+
+        // TODO from below here
+        // removedPendingEvents,
+        // roomEncryption,
+        // encryptionChanges,
+    }
+}
+
 export interface SyncChanges extends Event {
     type: SyncEvent.SyncChanges;
     data: {
         session: SessionChanges,
+        rooms: RoomChanges[],
     }
 }


### PR DESCRIPTION
Broadcast session and room-level sync changes from worker to main thread(s).

Encrypted rooms are not yet implemented, that will be addressed in the next PR.

## Summary of changes
1. Introduce a `SendQueuePool` which allows us to listen to newly-generated events across all rooms. These events are then propagated to the worker. Since "pending events" are handled as part of the sync process, the worker needs to be aware of them so that the sync properly removes them as pending.
2. Serialize and deserialize sync changes on the worker and in the main thread, respectively.

## Screen recordings

https://user-images.githubusercontent.com/550401/230424526-5b856f44-e0b3-4509-90b7-064c7baa407a.mov


https://user-images.githubusercontent.com/550401/230432635-9014a18c-bc88-4ac6-91e9-35061252f81a.mov




