### PR TITLE
Don't prevent concurrent session access when running sync in a worker

### DIFF
--- a/src/matrix/storage/idb/StorageFactory.ts
+++ b/src/matrix/storage/idb/StorageFactory.ts
@@ -53,19 +53,25 @@ async function requestPersistedStorage(): Promise<boolean> {
 
 export class StorageFactory {
     private _serviceWorkerHandler?: ServiceWorkerHandler;
+    private _runSyncInWorker: boolean;
     private _idbFactory: IDBFactory;
     private _IDBKeyRange: typeof IDBKeyRange;
     private _localStorage: IDOMStorage;
 
-    constructor(serviceWorkerHandler?: ServiceWorkerHandler, idbFactory: IDBFactory = self.indexedDB, _IDBKeyRange = self.IDBKeyRange, localStorage: IDOMStorage = self.localStorage) {
+    constructor(serviceWorkerHandler?: ServiceWorkerHandler, runSyncInWorker: boolean = false, idbFactory: IDBFactory = self.indexedDB, _IDBKeyRange = self.IDBKeyRange, localStorage: IDOMStorage = self.localStorage) {
         this._serviceWorkerHandler = serviceWorkerHandler;
+        this._runSyncInWorker = runSyncInWorker;
         this._idbFactory = idbFactory;
         this._IDBKeyRange = _IDBKeyRange;
         this._localStorage = localStorage;
     }
 
     async create(sessionId: string, log: ILogItem): Promise<Storage> {
-        await this._serviceWorkerHandler?.preventConcurrentSessionAccess(sessionId);
+        // When sync is running in a worker, we do not need to prevent concurrent session access.
+        if (!this._runSyncInWorker) {
+            await this._serviceWorkerHandler?.preventConcurrentSessionAccess(sessionId);
+        }
+
         requestPersistedStorage().then(persisted => {
             // Firefox lies here though, and returns true even if the user denied the request
             if (!persisted) {

--- a/src/mocks/Storage.ts
+++ b/src/mocks/Storage.ts
@@ -23,7 +23,7 @@ import {openDatabase, CreateObjectStore} from "../matrix/storage/idb/utils";
 export async function createMockStorage(): Promise<Storage> {
     const idbFactory = await createMockIDBFactory();
     const FDBKeyRange = await getMockIDBKeyRange();
-    return new StorageFactory(null as any, idbFactory, FDBKeyRange, new MockLocalStorage()).create("1", nullLogger.item);
+    return new StorageFactory(null as any, false, idbFactory, FDBKeyRange, new MockLocalStorage()).create("1", nullLogger.item);
 }
 
 // don't import fake-indexeddb until it's safe to assume we're actually in a unit test,

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -224,7 +224,7 @@ export class Platform {
                 }
 
                 this.syncFactory = new SyncFactory({logger: this.logger, runSyncInWorker: this.runSyncInWorker});
-                this.storageFactory = new StorageFactory(this._serviceWorkerHandler);
+                this.storageFactory = new StorageFactory(this._serviceWorkerHandler, this._runSyncInWorker);
             });
         } catch (err) {
             this._container.innerText = err.message;

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -173,6 +173,11 @@ export class Platform {
         this.mediaDevices = new MediaDevicesWrapper(navigator.mediaDevices);
         this.webRTC = new DOMWebRTC();
         this._themeLoader = import.meta.env.DEV? null: new ThemeLoader(this);
+        this._runSyncInWorker = undefined;
+    }
+
+    get runSyncInWorker() {
+        return this._runSyncInWorker;
     }
 
     async init() {
@@ -207,8 +212,18 @@ export class Platform {
                     log.log({ l: "Active theme", name: themeName, variant: themeVariant });
                     await this._themeLoader.setTheme(themeName, themeVariant, log);
                 }
+
                 this.features = await FeatureSet.load(this.settingsStorage);
-                this.syncFactory = new SyncFactory({logger: this.logger, features: this.features});
+                this._runSyncInWorker = this.features.sameSessionInMultipleTabs;
+                if (typeof SharedWorker === "undefined") {
+                    this._runSyncInWorker = false;
+                }
+                if (!window.WebAssembly) {
+                    // Sync worker currently only supports Olm through Wasm.
+                    this._runSyncInWorker = false;
+                }
+
+                this.syncFactory = new SyncFactory({logger: this.logger, runSyncInWorker: this.runSyncInWorker});
                 this.storageFactory = new StorageFactory(this._serviceWorkerHandler);
             });
         } catch (err) {

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -155,7 +155,6 @@ export class Platform {
         if(this._assetPaths.olm) {
             this.crypto = new Crypto(cryptoExtras);
         }
-        this.storageFactory = new StorageFactory(this._serviceWorkerHandler);
         this.sessionInfoStorage = new SessionInfoStorage("hydrogen_sessions_v1");
         this.estimateStorageUsage = estimateStorageUsage;
         if (typeof fetch === "function") {
@@ -210,6 +209,7 @@ export class Platform {
                 }
                 this.features = await FeatureSet.load(this.settingsStorage);
                 this.syncFactory = new SyncFactory({logger: this.logger, features: this.features});
+                this.storageFactory = new StorageFactory(this._serviceWorkerHandler);
             });
         } catch (err) {
             this._container.innerText = err.message;

--- a/src/platform/web/sync/SyncFactory.ts
+++ b/src/platform/web/sync/SyncFactory.ts
@@ -26,7 +26,7 @@ import {HomeServerApi} from "../../../matrix/net/HomeServerApi";
 
 type Options = {
     logger: Logger;
-    features: FeatureSet;
+    runSyncInWorker: boolean;
 }
 
 type MakeOptions = {
@@ -37,28 +37,18 @@ type MakeOptions = {
 
 export class SyncFactory {
     private readonly _logger: Logger;
-    private readonly _features: FeatureSet;
+    private readonly _runSyncInWorker: boolean;
 
     constructor(options: Options) {
-        const {logger, features} = options;
+        const {logger, runSyncInWorker} = options;
         this._logger = logger;
-        this._features = features;
+        this._runSyncInWorker = runSyncInWorker;
     }
 
     make(options: MakeOptions): ISync {
         const {hsApi, storage, session} = options;
-        let runSyncInWorker = this._features.sameSessionInMultipleTabs;
 
-        if (typeof SharedWorker === "undefined") {
-            runSyncInWorker = false;
-        }
-
-        if (!window.WebAssembly) {
-            // Sync worker currently only supports Olm through Wasm.
-            runSyncInWorker = false;
-        }
-
-        if (runSyncInWorker) {
+        if (this._runSyncInWorker) {
             return new SyncProxy({session, logger: this._logger});
         }
 

--- a/src/platform/web/sync/SyncProxy.ts
+++ b/src/platform/web/sync/SyncProxy.ts
@@ -149,6 +149,9 @@ export class SyncProxy implements ISync {
                     log.log({l: roomId, ...changes});
 
                     const room = rooms.get(roomId);
+                    if (!room) {
+                        continue;
+                    }
                     const deserializedRoomChanges = deserializeRoomChanges(room, roomChanges);
 
                     room.sendQueue.removePendingEvents(deserializedRoomChanges.changes.removedPendingEvents);

--- a/src/platform/web/sync/SyncProxy.ts
+++ b/src/platform/web/sync/SyncProxy.ts
@@ -127,6 +127,13 @@ export class SyncProxy implements ISync {
     private async onSyncChanges(event: SyncChanges): Promise<void> {
         const sessionChanges = event.data.session;
         const roomsChanges = event.data.rooms;
+        const isInitialSync = event.data.syncStatus === SyncStatus.InitialSync;
+
+        if (isInitialSync) {
+            // For the initial sync, instead of handling sync changes, we simply reload.
+            location.reload();
+            return;
+        }
 
         await this._logger.run("sync changes", async log => {
             await log.wrap("session", log => {
@@ -145,7 +152,7 @@ export class SyncProxy implements ISync {
                     const deserializedRoomChanges = deserializeRoomChanges(room, roomChanges);
 
                     room.sendQueue.removePendingEvents(deserializedRoomChanges.changes.removedPendingEvents);
-                    // We already remove pending events, so we don't want room.afterSync() to try to remove them again.
+                    // We already removed pending events, so we don't want room.afterSync() to try to remove them again.
                     // So we set the removedPendingEvents array to empty.
                     deserializedRoomChanges.changes.removedPendingEvents = [];
                     room.afterSync(deserializedRoomChanges.changes, log);

--- a/src/platform/web/sync/SyncProxy.ts
+++ b/src/platform/web/sync/SyncProxy.ts
@@ -93,6 +93,7 @@ export class SyncProxy implements ISync {
         };
 
         const response = await this._workerProxy.sendAndWaitForResponse(request) as StartSyncResponse;
+        this._status.set(response.data.syncStatus);
         if (response?.error) {
             throw response.error;
         }

--- a/src/platform/web/worker/WorkerProxy.ts
+++ b/src/platform/web/worker/WorkerProxy.ts
@@ -50,7 +50,7 @@ export class WorkerProxy {
         const request = response.request;
         const ongoingRequest = this._requests.get(request.id);
         if (!ongoingRequest) {
-            throw `Request with id ${request.id} was not found`;
+            return;
         }
 
         this._requests.delete(request.id);

--- a/src/platform/workers/sync/SyncInWorker.ts
+++ b/src/platform/workers/sync/SyncInWorker.ts
@@ -56,6 +56,7 @@ export class SyncInWorker extends Sync {
             type: SyncEvent.SyncChanges,
             id: makeEventId(),
             data: {
+                syncStatus: this.status.get(),
                 session: sessionChanges,
                 rooms: roomsChanges,
             }

--- a/src/platform/workers/sync/SyncWorker.ts
+++ b/src/platform/workers/sync/SyncWorker.ts
@@ -71,7 +71,7 @@ export class SyncWorker extends SharedWorker {
     }
 
     async startSync(request: StartSyncRequest): Promise<StartSyncResponse> {
-        const response: StartSyncResponse = {request, data: {}};
+        const response: StartSyncResponse = {request, data: { syncStatus: this._sync?.status.get()}};
         if (this._sync) {
             return response;
         }
@@ -98,6 +98,7 @@ export class SyncWorker extends SharedWorker {
         this._sync.status.subscribe(this.onSyncStatusChanged.bind(this));
 
         await this._sync.start();
+        response.data.syncStatus = this._sync.status.get();
 
         return response;
     }

--- a/src/platform/workers/sync/sync-worker.ts
+++ b/src/platform/workers/sync/sync-worker.ts
@@ -19,15 +19,14 @@ import assetPaths from "../../web/sdk/paths/vite";
 
 declare const self;
 
-// Vite makes the paths relative (e.g. ./assets/olm.abc123.js) but we want the absolute path, so we strip the
-// leading `.`.
-// TODO: Fix this at vite level.
-const olmWasmJsPath = assetPaths.olm.wasmBundle.substring(1);
-const olmWasmPath = assetPaths.olm.wasm.substring(1);
-
 self.syncWorker = new SyncWorker({
     assets: {
-        olmWasmJsPath: olmWasmJsPath,
-        olmWasmPath: olmWasmPath,
+        olmWasmJsPath: assetPath(assetPaths.olm.wasmBundle),
+        olmWasmPath: assetPath(assetPaths.olm.wasm),
     }
 });
+
+function assetPath(path) {
+    // sync-worker is in the /assets directory, as are all assets, so we load assets relative to that directory.
+    return path.replace(/(\.\/)?assets\//, "./");
+}

--- a/src/platform/workers/types/sync.ts
+++ b/src/platform/workers/types/sync.ts
@@ -22,7 +22,9 @@ export interface StartSyncRequest extends Request {
 }
 export interface StartSyncResponse extends Response {
     request: StartSyncRequest;
-    data: {}
+    data: {
+        syncStatus: string,
+    }
 }
 
 export interface AddPendingEventRequest extends Request {

--- a/src/platform/workers/types/sync.ts
+++ b/src/platform/workers/types/sync.ts
@@ -90,6 +90,7 @@ export type RoomChanges = {
 export interface SyncChanges extends Event {
     type: SyncEvent.SyncChanges;
     data: {
+        syncStatus: string,
         session: SessionChanges,
         rooms: RoomChanges[],
     }


### PR DESCRIPTION
When sync is running in a worker, we don't need to prevent concurrent session access, since we want to have multiple tabs/windows/iframes open with the same session.